### PR TITLE
Set the default VSCode interpreter to venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     "/opt/ros/jazzy/local/lib/python3.12/dist-packages/",
     "${workspaceFolder}/install/"
   ],
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/ros2-template/bin/python",
   "C_Cpp.default.intelliSenseMode": "linux-gcc-x86",
   "C_Cpp.clang_format_fallbackStyle": "Google",
   "C_Cpp.codeAnalysis.clangTidy.enabled": true,


### PR DESCRIPTION
## Changes Made

With the update to Noble, virtual environments are required for Python package installation. This PR updates the VSCode settings to use the venv as the default interpreter.
